### PR TITLE
fix(productivity-suite): ensure the todos fragment has an id for hydration

### DIFF
--- a/productivity-suite/app/fragments/todos/src/worker/index.tsx
+++ b/productivity-suite/app/fragments/todos/src/worker/index.tsx
@@ -46,9 +46,11 @@ export default {
       env
     ).then((res) => res.text());
 
-    const [pre, post] = initialPageHtml.split(
-      '<div id="todos-fragment-root"></div>'
-    );
+    const appRootElement = '<div id="todos-fragment-root">';
+    const indexOfFragmentDiv = initialPageHtml.indexOf(appRootElement);
+    const indexForFragment = indexOfFragmentDiv + appRootElement.length;
+    const pre = initialPageHtml.slice(0, indexForFragment);
+    const post = initialPageHtml.slice(indexForFragment);
     const stream = wrapStreamInText(
       pre,
       post,


### PR DESCRIPTION
A previous commit (of mine) broke the rehydration of this fragment by stripping
the div that was used as the marker for the root of the component to rehydrate.

This fix moves the id onto the root of the `App` component itself.