### PR TITLE
fix(productivity-suite) turn minification back off in the news fragment to fix an issue

### DIFF
--- a/productivity-suite/app/fragments/news/vite.config.ts
+++ b/productivity-suite/app/fragments/news/vite.config.ts
@@ -30,6 +30,9 @@ export function wrapAndExportMount(regex: RegExp): PluginOption {
 
 export default defineConfig({
   base: "/_fragment/news",
+  build: {
+    minify: false,
+  },
   ssr: {
     // Vite attempts to load this as a Commonjs dependency
     noExternal: ["solid-meta"],


### PR DESCRIPTION
The default export plugin we wrote breaks if vite minifies the solid output before it runs. This causes a regression in the news tab