### PR TITLE
fix(productivity-suite): add a fallback option when loading news pages

### DIFF
--- a/productivity-suite/app/fragments/news/src/root.css
+++ b/productivity-suite/app/fragments/news/src/root.css
@@ -34,6 +34,10 @@ a {
   width: 100%;
 }
 
+.news-list.pending * {
+  color: grey;
+}
+
 .news-list ul {
   list-style-type: none;
   padding: 0;

--- a/productivity-suite/app/fragments/news/src/routes/[...news].tsx
+++ b/productivity-suite/app/fragments/news/src/routes/[...news].tsx
@@ -10,26 +10,13 @@ import Story from "~/components/story";
 import fetchAPI from "~/lib/api";
 import { IStory } from "~/types";
 
-const StoryList: Component<{ page: number }> = (props) => {
-  const [stories] = createResource<IStory[], string>(
-    () => `news?page=${props.page}`,
-    fetchAPI
-  );
-  return (
-    <main class="news-list">
-      <Suspense>
-        <Show when={stories()}>
-          <ul>
-            <For each={stories()}>{(story) => <Story story={story} />}</For>
-          </ul>
-        </Show>
-      </Suspense>
-    </main>
-  );
-};
-
 export default function News() {
   const [page, setPage] = createSignal<number>(1);
+
+  const [stories] = createResource<IStory[], string>(
+    () => `news?page=${page()}`,
+    fetchAPI
+  );
 
   return (
     <div class="news-view">
@@ -42,26 +29,28 @@ export default function News() {
             </span>
           }
         >
-          <button
-            class="page-link"
-            onClick={() => {
-              setPage(page() - 1);
-            }}
-          >
+          <button class="page-link" onClick={() => setPage(page() - 1)}>
             {"<"} prev
           </button>
         </Show>
         <span>page {page()}</span>
-        <button
-          class="page-link"
-          onClick={() => {
-            setPage(page() + 1);
-          }}
-        >
+        <button class="page-link" onClick={() => setPage(page() + 1)}>
           more {">"}
         </button>
       </div>
-      <StoryList page={page()}></StoryList>
+      <main class="news-list" classList={{ pending: stories.loading }}>
+        <Suspense fallback={<StoryList stories={stories.latest}></StoryList>}>
+          <StoryList stories={stories()}></StoryList>
+        </Suspense>
+      </main>
     </div>
   );
 }
+
+const StoryList: Component<{ stories: IStory[] }> = (props) => {
+  return (
+    <ul>
+      <For each={props.stories}>{(story) => <Story story={story} />}</For>
+    </ul>
+  );
+};


### PR DESCRIPTION
Now we use `stories.latest` to render the "previous" page of news stories when we are waiting for the new page to arrive.