### PR TITLE
fix(productivity-suite): Make index route redirect to /todos again

### DIFF
--- a/productivity-suite/app/legacy-app/src/App.tsx
+++ b/productivity-suite/app/legacy-app/src/App.tsx
@@ -38,13 +38,14 @@ export default function App() {
 
 const ProtectedRoutes = (
   <Route
+    path="/"
     element={
       <RequireAuth>
         <Outlet />
       </RequireAuth>
     }
   >
-    <Route path="/" element={<Navigate to="/todos" />} />
+    <Route index element={<Navigate to="/todos" />} />
     <Route path="/todos" element={<TodoLists />} />
     <Route path="/todos/:listName" element={<TodoLists />} />
     <Route path="/calendar" element={<Calendar />} />


### PR DESCRIPTION
The recently introduced `*` route was taking precedence over the current redirect. Explicitly marking this as the `index` route fixes the issue