### PR TITLE
feat(productivity-suite): slightly improve selected-list delete-btn

### DIFF
--- a/productivity-suite/app/fragments/todo-lists/src/components/SelectedListCard.css
+++ b/productivity-suite/app/fragments/todo-lists/src/components/SelectedListCard.css
@@ -15,7 +15,7 @@
     }
 
     .selected-list > span {
-        padding: 2.5rem .5rem;
+        padding: .5rem .5rem;
     }
 }
 
@@ -48,16 +48,20 @@
 .delete-btn {
     cursor: pointer;
     position: absolute;
-    top: -0.3em;
-    right: -0.3em;
-    padding: 1em;
+    top: 0.5em;
+    right: 0.6em;
+    padding: 0.1em;
     z-index: inherit;
-    font-size: 1.5rem;
-    line-height: 1ex;
+    font-size: 1.3rem;
+    line-height: 1;
     border-color: transparent;
     color: #4d4d4d;
     background-color: transparent;
     font-weight: 300;
+}
+
+.delete-btn:hover {
+    opacity: 0.7;
 }
 
 .delete-btn:disabled {

--- a/productivity-suite/app/fragments/todo-lists/src/components/SelectedListCard.tsx
+++ b/productivity-suite/app/fragments/todo-lists/src/components/SelectedListCard.tsx
@@ -24,7 +24,7 @@ export const SelectedListCard = component$(
   }) => {
     useStylesScoped$(styles);
 
-    const newTodoInputState = useStore<{
+    const todoListInputState = useStore<{
       editing: boolean;
       value: string | null;
       valid: boolean;
@@ -41,16 +41,16 @@ export const SelectedListCard = component$(
 
     useWatch$(({ track }) => {
       track(() => listName);
-      newTodoInputState.editing = false;
+      todoListInputState.editing = false;
     });
 
     const handleInputChange = $((event: Event) => {
       const value = (event.target as HTMLInputElement).value;
-      newTodoInputState.value = value;
-      newTodoInputState.dirty = true;
+      todoListInputState.value = value;
+      todoListInputState.dirty = true;
       const trimmedValue = value.trim();
       if (trimmedValue === listName) {
-        newTodoInputState.valid = true;
+        todoListInputState.valid = true;
         return;
       }
       if (
@@ -58,29 +58,29 @@ export const SelectedListCard = component$(
         trimmedValue.length > 20 ||
         !!todoListsNames.includes(trimmedValue)
       ) {
-        newTodoInputState.valid = false;
+        todoListInputState.valid = false;
         return;
       }
-      newTodoInputState.valid = true;
+      todoListInputState.valid = true;
     });
 
     const editListNameIfValid = $(async () => {
-      const newListName = newTodoInputState.value!.trim();
+      const newListName = todoListInputState.value!.trim();
       if (
         listName !== newListName &&
-        newTodoInputState.dirty &&
-        newTodoInputState.valid
+        todoListInputState.dirty &&
+        todoListInputState.valid
       ) {
         const success = await onEditListName$(newListName);
         if (success) {
-          newTodoInputState.editing = false;
+          todoListInputState.editing = false;
         }
       }
     });
 
     const handleInputBlur = $(() => {
       editListNameIfValid();
-      newTodoInputState.editing = false;
+      todoListInputState.editing = false;
     });
 
     const handleInputKeyUp = $((event: KeyboardEvent) => {
@@ -89,38 +89,42 @@ export const SelectedListCard = component$(
       }
     });
 
+    const startEditing = $(() => {
+      if (!todoListInputState.editing) {
+        todoListInputState.editing = true;
+        todoListInputState.value = listName;
+        todoListInputState.valid = true;
+        todoListInputState.dirty = false;
+      }
+    });
+
     return (
       <div class="todo-list-card selected-list-wrapper">
-        <button
+        <div
+          tabIndex={0}
           class="todo-list-card selected-list"
-          onClick$={() => {
-            if (!newTodoInputState.editing) {
-              newTodoInputState.editing = true;
-              newTodoInputState.value = listName;
-              newTodoInputState.valid = true;
-              newTodoInputState.dirty = false;
-            }
-          }}
+          onClick$={startEditing}
+          onKeyDown$={(event) => event.code === "Enter" && startEditing()}
         >
-          {!newTodoInputState.editing && <span>{listName}</span>}
-          {newTodoInputState.editing && (
+          {!todoListInputState.editing && <span>{listName}</span>}
+          {todoListInputState.editing && (
             <input
               enterKeyHint="done"
               ref={editRef}
               type="text"
               class={`selected-list-edit ${
-                newTodoInputState.valid ? "" : "invalid"
+                todoListInputState.valid ? "" : "invalid"
               }`}
-              value={newTodoInputState.value ?? undefined}
+              value={todoListInputState.value ?? undefined}
               onInput$={handleInputChange}
               onBlur$={handleInputBlur}
               onKeyUp$={handleInputKeyUp}
             />
           )}
-        </button>
+        </div>
         <button
           class="btn delete-btn"
-          disabled={newTodoInputState.editing || todoListsNames.length <= 1}
+          disabled={todoListInputState.editing || todoListsNames.length <= 1}
           onClick$={onDeleteList$}
           aria-label="delete list"
         >


### PR DESCRIPTION
improve the selected-list delete button so that it doesn't overflow the container nor does it need to have a big padding or font-size

for this fix the selected-list has been converted to a div instead of a button which was apparently making lighthouse considering all its content text which should not be overlapped

by having it as a div we avoid such issue (although this is slightly worse a11y-wise)

___

Before:
![Screenshot 2022-11-16 at 10 34 39](https://user-images.githubusercontent.com/61631103/202158871-5510ae0e-3a68-43d5-ac36-d023b97b0483.png)

After:
![Screenshot 2022-11-16 at 10 34 21](https://user-images.githubusercontent.com/61631103/202158937-961f1b6d-0845-4164-9232-ddfaab29c826.png)

(The SEO score is still at 100:
![Screenshot 2022-11-16 at 10 35 07](https://user-images.githubusercontent.com/61631103/202158990-a5b6cc9d-54ca-4a8d-b005-d3583706cdcf.png))

(the 92 for best-practices happens locally because we get the `rum` error in the console)