### PR TITLE
fix(productivity-suite): fix the todo-list deletion buggy behavior

### DIFF
--- a/productivity-suite/app/fragments/todo-lists/src/components/ListsCarouselAnimations.css
+++ b/productivity-suite/app/fragments/todo-lists/src/components/ListsCarouselAnimations.css
@@ -7,7 +7,7 @@
 }
 
 .todo-list-card {
-    animation-duration: 0.15s;
+    animation-duration: 0.13s;
     animation-timing-function: cubic-bezier(.55,.51,.47,.99);;
 }
 

--- a/productivity-suite/app/fragments/todo-lists/src/root.tsx
+++ b/productivity-suite/app/fragments/todo-lists/src/root.tsx
@@ -94,6 +94,9 @@ export const Root = component$(() => {
             initialTodoLists={state.todoLists}
             idxOfSelectedList={state.idxOfSelectedList}
             selectedListName={state.selectedListName}
+            onUpdateTodoLists$={(lists) => {
+              state.todoLists = lists;
+            }}
             onUpdateSelectedListDetails$={({
               idx,
               name,


### PR DESCRIPTION
fix the buggy behavior we get when we delete a list in the todo-lists fragment by keeping the root todoLists up to date and slightly tweaking the animation