### PR TITLE
fix(productivity-suite): use the correct index in todo-lists useServerMount

### DIFF
--- a/productivity-suite/app/fragments/todo-lists/src/root.tsx
+++ b/productivity-suite/app/fragments/todo-lists/src/root.tsx
@@ -51,7 +51,7 @@ export const Root = component$(() => {
     );
 
     state.idxOfSelectedList = idx !== -1 ? idx : state.todoLists.length - 1;
-    state.selectedListName = state.todoLists[idx].name;
+    state.selectedListName = state.todoLists[state.idxOfSelectedList].name;
   });
 
   const ref = useSignal<Element>();


### PR DESCRIPTION
in the useServerMount for the todo-lists fragment we take the name of the selected list using idx, which can be -1 instead of using the amended idxOfSelectedList causing a possible crash on the server, fix this issue by using the appropriate index