### PR TITLE
fix(productivity-suite): ensure that we only run side-effects once per fragment

### DIFF
--- a/productivity-suite/app/fragments/todos/src/App.tsx
+++ b/productivity-suite/app/fragments/todos/src/App.tsx
@@ -68,7 +68,7 @@ const App: React.FC<{
 
   useEffect(() => {
     if (ref.current) {
-      const remover = getBus(ref.current).listen<{ name: string }>(
+      return getBus(ref.current).listen<{ name: string }>(
         "todo-list-selected",
         async (listDetails) => {
           if (listDetails) {
@@ -80,7 +80,6 @@ const App: React.FC<{
           }
         }
       );
-      return remover ?? undefined;
     }
   }, [ref.current]);
 


### PR DESCRIPTION
Previously, if an outlet was added and then removed quickly, before the fragment had completed its execution, we still added it to the set of previously unmounted fragments. This meant that when the outlet got added a second time, we would manually run the side-effects, even though they would still be automatically run as part of the first-time load.

Now we only add fragments to the previously unmounted set if it completed its execution.