### PR TITLE
refactor(productivity-suite): update SolidJS version to avoid global leak workaround

### DIFF
--- a/productivity-suite/app/fragments/news/package.json
+++ b/productivity-suite/app/fragments/news/package.json
@@ -9,16 +9,16 @@
   "type": "module",
   "main": "./dist/index.js",
   "devDependencies": {
+    "shared": "file:../../shared",
+    "solid-js": "^1.6.2",
     "solid-start-cloudflare-workers": "^0.2.2",
     "solid-start-node": "^0.2.2",
     "typescript": "^4.8.4",
     "vite": "^3.1.8",
-    "wrangler": "^2.1.13",
-    "shared": "file:../../shared"
+    "wrangler": "^2.1.13"
   },
   "dependencies": {
     "@solidjs/meta": "^0.28.0",
-    "solid-js": "^1.6.1",
     "solid-start": "^0.2.2",
     "undici": "^5.11.0"
   },

--- a/productivity-suite/app/legacy-app/src/components/pages/News.tsx
+++ b/productivity-suite/app/legacy-app/src/components/pages/News.tsx
@@ -1,16 +1,4 @@
-import { useEffect } from "react";
-
 export function News() {
-  useEffect(() => {
-    return () => {
-      // @ts-ignore
-      window.e = window._$HY = null;
-
-      // @ts-ignore
-      window.t = function () {};
-    };
-  });
-
   return (
     <div>
       <piercing-fragment-outlet fragment-id="news" />

--- a/productivity-suite/package-lock.json
+++ b/productivity-suite/package-lock.json
@@ -56,12 +56,12 @@
 			"name": "productivity-suite-news-fragment",
 			"dependencies": {
 				"@solidjs/meta": "^0.28.0",
-				"solid-js": "^1.6.1",
 				"solid-start": "^0.2.2",
 				"undici": "^5.11.0"
 			},
 			"devDependencies": {
 				"shared": "file:../../shared",
+				"solid-js": "^1.6.2",
 				"solid-start-cloudflare-workers": "^0.2.2",
 				"solid-start-node": "^0.2.2",
 				"typescript": "^4.8.4",
@@ -8289,9 +8289,9 @@
 			}
 		},
 		"node_modules/solid-js": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.6.1.tgz",
-			"integrity": "sha512-i8OmR419Hr0918Or6sm1ET/cgmxTtAB7Bdz/UwhZ7G2THixrvVSO3jd+C7YqMKKfVwmf8PJ2gUSbKE8NKv28GA==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.6.2.tgz",
+			"integrity": "sha512-AZBsj+Yn1xliniTTeuQKG9V7VQVkQ8lZmSKvBjpcVSoZeF7nvt/N5f7Kcsx6QSufioa2YgvBjkIiA0cM0qhotw==",
 			"dependencies": {
 				"csstype": "^3.1.0"
 			}
@@ -13461,7 +13461,7 @@
 			"requires": {
 				"@solidjs/meta": "^0.28.0",
 				"shared": "file:../../shared",
-				"solid-js": "^1.6.1",
+				"solid-js": "1.6.2",
 				"solid-start": "^0.2.2",
 				"solid-start-cloudflare-workers": "^0.2.2",
 				"solid-start-node": "^0.2.2",
@@ -14860,9 +14860,9 @@
 			"dev": true
 		},
 		"solid-js": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.6.1.tgz",
-			"integrity": "sha512-i8OmR419Hr0918Or6sm1ET/cgmxTtAB7Bdz/UwhZ7G2THixrvVSO3jd+C7YqMKKfVwmf8PJ2gUSbKE8NKv28GA==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.6.2.tgz",
+			"integrity": "sha512-AZBsj+Yn1xliniTTeuQKG9V7VQVkQ8lZmSKvBjpcVSoZeF7nvt/N5f7Kcsx6QSufioa2YgvBjkIiA0cM0qhotw==",
 			"requires": {
 				"csstype": "^3.1.0"
 			}


### PR DESCRIPTION
Previously, SolidJS (used in the news fragment) was leaving data on the global object, which broke the news component when the application tried to re-render it after navigating away.

Updating to the latest SolidJS version 1.6.2 fixes this problem, so we can remove the workaround.