### PR TITLE
fix(productivity-suite): ensure that `_$HY` is still cleaned up

### DIFF
--- a/productivity-suite/app/legacy-app/src/components/pages/News.tsx
+++ b/productivity-suite/app/legacy-app/src/components/pages/News.tsx
@@ -1,4 +1,13 @@
+import { useEffect } from "react";
+
 export function News() {
+  useEffect(() => {
+    return () => {
+      // @ts-ignore
+      window._$HY = null;
+    };
+  });
+
   return (
     <div>
       <piercing-fragment-outlet fragment-id="news" />


### PR DESCRIPTION
In 48c2504633fe225e08129cb9f1f4df25c28e0371 we removed the `_$HY` cleanup workaround because SolidJS had released a version that we thought fixed this but it looks like although the minified properties have been removed from the window, the `_$HY` property is still there.