### PR TITLE
fix(productivity-suite): add missing text-align center for todo-list cards

### DIFF
--- a/productivity-suite/app/fragments/todo-lists/src/components/TodoListsCarousel.css
+++ b/productivity-suite/app/fragments/todo-lists/src/components/TodoListsCarousel.css
@@ -8,6 +8,7 @@
 
 .todo-lists-carousel :global(.todo-list-card) {
     font-size: 2rem;
+    text-align: center;
     display: grid;
     place-items: center;
     color: #4d4d4d;


### PR DESCRIPTION
before:
![Screenshot 2022-12-02 at 17 59 10](https://user-images.githubusercontent.com/61631103/205356745-bac40ad7-0b36-4bca-b96c-fdd2ca91b3fc.png)

after:
![Screenshot 2022-12-02 at 17 58 36](https://user-images.githubusercontent.com/61631103/205356728-5bba85c8-75b8-42ff-af5b-dee05ea27946.png)
