### PR TITLE
fix(productivity-suite): if not logged in, the whole of the authentication message should be null

### DIFF
--- a/productivity-suite/app/legacy-app/src/worker/script.ts
+++ b/productivity-suite/app/legacy-app/src/worker/script.ts
@@ -18,21 +18,19 @@ const gateway = new PiercingGateway<Env>({
   },
   async generateMessageBusState(requestMessageBusState, request) {
     const requestCookie = request.headers.get("Cookie");
-    const currentUser = requestCookie
-      ? await getCurrentUser(requestCookie)
-      : null;
+    const username = requestCookie ? await getCurrentUser(requestCookie) : null;
 
     if (!("authentication" in requestMessageBusState)) {
-      requestMessageBusState["authentication"] = {
-        username: currentUser,
+      requestMessageBusState["authentication"] = username && {
+        username,
       };
     }
 
-    if (!("todo-list-selected" in requestMessageBusState) && currentUser) {
+    if (!("todo-list-selected" in requestMessageBusState) && username) {
       const match = /\/todos\/([^/]+)$/.exec(request.url);
       let listName = match?.[1] && decodeURIComponent(match[1]);
 
-      const lists = await getTodoLists(currentUser, requestCookie!);
+      const lists = await getTodoLists(username, requestCookie!);
       // make sure that the provided listName is the name of an existing list
       listName = lists.find(({ name }) => name === listName)?.name;
 


### PR DESCRIPTION
In 8511de217bba7dae2ac54d0f4b229b7cd20bce5b the clientside code was updated to assume that the `authentication` message was either `{username: string}` or `null`. But the gateway worker configuration was putting `{username: null}` when the user was not authenticated.